### PR TITLE
Fix rendering in slim templates

### DIFF
--- a/lib/bootstrap_forms/form_builder.rb
+++ b/lib/bootstrap_forms/form_builder.rb
@@ -82,9 +82,8 @@ module BootstrapForms
           content_tag(:label, checkbox, :class => ['checkbox', ('inline' if @field_options[:inline])].compact.join(' '))
         end.join('')
 
-        content_tag(:div, :class => 'controls') do
-          label_field << extras { boxes }
-        end
+        content = label_field << extras { boxes }
+        content_tag(:div, content, :class => 'controls')
       end
     end
 
@@ -100,9 +99,8 @@ module BootstrapForms
           content_tag(:label, radiobutton, :class => ['radio', ('inline' if @field_options[:inline])].compact.join(' '))
         end.join('')
 
-        content_tag(:div, :class => 'controls') do
-          label_field << extras { buttons }
-        end
+        content = label_field << extras { buttons }
+        content_tag(:div, content, :class => 'controls')
       end
     end
 
@@ -129,9 +127,8 @@ module BootstrapForms
     end
 
     def actions(&block)
-      content_tag(:div, :class => 'form-actions') do
-        block_given? ? capture_html(&block) : [submit, cancel].join(' ')
-      end
+      content = block_given? ? capture_html(&block) : [submit, cancel].join(' ')
+      content_tag(:div, content, :class => 'form-actions')
     end
   end
 end

--- a/lib/bootstrap_forms/helpers/form_tag_helper.rb
+++ b/lib/bootstrap_forms/helpers/form_tag_helper.rb
@@ -79,13 +79,8 @@ module BootstrapForms
       end
 
       def bootstrap_actions(&block)
-        content_tag(:div, :class => 'form-actions') do
-          if block_given?
-            capture_html(&block)
-          else
-            [bootstrap_submit_tag, bootstrap_cancel_tag].join(' ')
-          end
-        end
+        content = block_given? ? capture_html(&block) : [bootstrap_submit_tag, bootstrap_cancel_tag].join(' ')
+        content_tag(:div, content, :class => 'form-actions')
       end
     end
   end


### PR DESCRIPTION
Under slim templating #content_tag must not be used with blocks.
