### PR TITLE
Loose dependencies to support newer versions of Padrino

### DIFF
--- a/padrino_bootstrap_forms.gemspec
+++ b/padrino_bootstrap_forms.gemspec
@@ -14,8 +14,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency "padrino", "~> 0.10.6"
-  s.add_dependency "activesupport", "~> 3.0"
+  s.add_dependency "padrino", ">= 0.10.6"
   s.add_development_dependency "rake"
   s.add_development_dependency "slim", "~> 1.3.6"
   s.add_development_dependency "haml", "~> 3.1"


### PR DESCRIPTION
Hey there,

Thanks for making up this gem, it really eases bootstrap's form creation!..

I was just about to try it out when I realised it doesn't really work with newer Padrino versions just because it's tied to the 0.10.x line.

On this PR I've relaxed the Padrino version and removed the activesupport dependency since Padrino will bring along the version it needs.

Cheers,
Darío
